### PR TITLE
feat: add predictionSource flag

### DIFF
--- a/services/prediction/features.yaml
+++ b/services/prediction/features.yaml
@@ -14,7 +14,7 @@ flags:
     rank: 1
     distributions:
     - variant: fromDB
-      rollout: 110
+      rollout: 100
 segments:
 - key: all-users
   name: All Users

--- a/services/prediction/features.yaml
+++ b/services/prediction/features.yaml
@@ -1,1 +1,22 @@
 namespace: prediction
+flags:
+- key: predictionSource
+  name: Prediction Source
+  description: The source of where to draw predictions.
+  enabled: true
+  variants:
+  - key: fromDB
+    name: From Database
+  - key: fromClosedAI
+    name: From ClosedAI
+  rules:
+  - segment: all-users
+    rank: 1
+    distributions:
+    - variant: fromDB
+      rollout: 110
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE


### PR DESCRIPTION
Define the `predictionSource` feature flag definition.

By default it returns `fromDB` variant for all requests.